### PR TITLE
Fix seeding for block committee and miner selection

### DIFF
--- a/app/codes/committeemanager.py
+++ b/app/codes/committeemanager.py
@@ -21,12 +21,17 @@ miner_committee_cache = {
 }
 
 
-def get_number_from_hash(block_hash):
+def get_number_from_hash(block):
     """
     Return a number from a string determinstically
     """
     # return hash(block_hash) % 1000000
-    return ord(block_hash[0])
+    if block['index'] > 90000:
+        seed = block['index'] + ord(block['hash'])
+        seed = seed % 1000000
+    else:
+        seed = ord(block['hash'][0])
+    return seed
 
 
 def weighted_random_choices(population, weights, k, seed_prefix=0):
@@ -73,7 +78,7 @@ def get_miner_for_current_block(last_block=None):
         logger.info('Inadequate committee. Sentinel node is the miner.')
         return {'wallet_address': SENTINEL_NODE_WALLET}
 
-    random.seed(get_number_from_hash(last_block['hash']))
+    random.seed(get_number_from_hash(last_block))
     miner = random.choice(committee_list)
     miner_committee_cache = {
         'current_block_hash': last_block['hash'],
@@ -153,7 +158,7 @@ def get_committee_for_current_block(last_block=None):
         miners,
         weights,
         committee_size,
-        get_number_from_hash(last_block['hash']))
+        get_number_from_hash(last_block))
     committee = sorted(committee, key=lambda d: d['wallet_address']) 
     return committee
 

--- a/app/constants.py
+++ b/app/constants.py
@@ -3,7 +3,7 @@ import os
 
 from .ntypes import NEWRL_TOKEN_CODE, NUSD_TOKEN_CODE
 
-SOFTWARE_VERSION = "1.2.4"
+SOFTWARE_VERSION = "1.3.0"
 
 NEWRL_ENV = os.environ.get('NEWRL_ENV')
 IS_TEST = os.environ.get('NEWRL_TEST') == 'Y'

--- a/app/routers/system.py
+++ b/app/routers/system.py
@@ -14,7 +14,7 @@ from fastapi.responses import PlainTextResponse
 from app.codes.chainscanner import download_chain, download_state, get_config
 from app.codes.clock.global_time import get_time_stats
 from app.codes.fs.mempool_manager import clear_mempool
-from app.codes.p2p.peers import add_peer, clear_peers, get_peers, remove_dead_peers, update_software
+from app.codes.p2p.peers import add_peer, clear_peers, get_peers, init_bootstrap_nodes, remove_dead_peers, update_software
 from app.codes.p2p.sync_chain import get_blocks, get_last_block_index, sync_chain_from_node, sync_chain_from_peers
 from app.codes.p2p.sync_mempool import list_mempool_transactions, sync_mempool_transactions
 from app.codes.timers import SYNC_STATUS
@@ -130,6 +130,12 @@ def get_status_api():
 def get_status_api():
     add_miners_as_peers()
     remove_dead_peers()
+    return {'status': 'SUCCESS'}
+
+
+@router.post("/init-nodes", tags=[p2p_tag])
+def get_status_api():
+    init_bootstrap_nodes()
     return {'status': 'SUCCESS'}
 
 


### PR DESCRIPTION
This should fix a no rewards issue for a large number of validators. 

Previously only the first character of previous block hash was being used to seed the random selection of committee and miner selection. This was not ideal as the rewards were quite uneven across nodes.  This change uses a new seed which includes the block index (new) as well as the first character of the hash (as earlier). This evens out the reward distribution as it's more efficiently random.

For illustration, if we assume an extreme case of permanently static pool of validators, the rewards distribution simulation before and after are as shown in the charts. These are only for illustration and do not denote actual differences of distribution. It is not the same on the network as the validator pools keep changing from one index to next. Hence the actual distribution has been somewhere in between the below two, before the proposed change. After the proposed change, it will be quite close to the "after" chart - which is more even.
 
![reward_distribution_before](https://user-images.githubusercontent.com/6903638/201921741-b0ba08a8-47ce-4363-a863-8bc5c0112c5d.png)
![reward_distribution_after](https://user-images.githubusercontent.com/6903638/201921758-f1862eed-8509-4032-9b63-fcf003782505.png)
