### PR TITLE
fix txn propagation termination

### DIFF
--- a/app/codes/chainscanner.py
+++ b/app/codes/chainscanner.py
@@ -93,7 +93,7 @@ def get_block(block_index):
     return chain.get_block(block_index)
 
 def get_transaction(transaction_code):
-    con = sqlite3.connect(NEWRL_DB)
+    con = sqlite3.connect('file:' + NEWRL_DB + '?mode=ro')
     con.row_factory = sqlite3.Row
     cur = con.cursor()
     transaction_cursor = cur.execute(

--- a/app/codes/validator.py
+++ b/app/codes/validator.py
@@ -17,6 +17,7 @@ from .utils import get_last_block_hash
 from .transactionmanager import Transactionmanager
 from ..constants import IS_TEST, MAX_TRANSACTION_SIZE, MEMPOOL_PATH, MEMPOOL_TRANSACTION_LIFETIME_SECONDS
 from .p2p.outgoing import propogate_transaction_to_peers
+from .chainscanner import get_transaction
 
 from jsonschema import validate as jsonvalidate
 
@@ -37,6 +38,9 @@ def validate(transaction, propagate=False, validate_economics=True):
     if transaction_exists_in_mempool(transaction['transaction']['trans_code']):
         return {'valid': True, 'msg': 'Already validated and in mempool', 'new_transaction': False}
     
+    if get_transaction(transaction['transaction']['trans_code']) is not None:
+        return {'valid': True, 'msg': 'Transaction exists in chain', 'new_transaction': False}
+
     if transaction['transaction']['type'] != TRANSACTION_MINER_ADDITION and transaction['transaction']['fee'] < 1000000:
         return {'valid': False, 'msg': 'Not enough fee. Min of 1 NWRL is required', 'new_transaction': True}
 

--- a/app/constants.py
+++ b/app/constants.py
@@ -3,7 +3,7 @@ import os
 
 from .ntypes import NEWRL_TOKEN_CODE, NUSD_TOKEN_CODE
 
-SOFTWARE_VERSION = "1.4.0"
+SOFTWARE_VERSION = "1.4.1"
 
 NEWRL_ENV = os.environ.get('NEWRL_ENV')
 IS_TEST = os.environ.get('NEWRL_TEST') == 'Y'

--- a/app/routers/blockchain.py
+++ b/app/routers/blockchain.py
@@ -366,7 +366,7 @@ def sign_transaction(wallet_data: dict, transaction_data: dict):
     return singed_transaction_file
 
 @router.post("/submit-transaction", tags=[submit_tag])
-@limiter.limit("1/second")
+@limiter.limit("10/second")
 async def submit_transaction(request: Request):
     """Submit a signed transaction and adds it to the chain"""
     try:

--- a/app/routers/p2p.py
+++ b/app/routers/p2p.py
@@ -60,7 +60,7 @@ def get_blocks_in_range_api(start_index: int, end_index: int):
     return get_blocks_in_range(start_index, end_index)
 
 @router.post("/receive-transaction", tags=[p2p_tag])
-@limiter.limit("50/second")
+@limiter.limit("10/second")
 async def receive_transaction_api(request: Request):
     signed_transaction = (await request.json())['signed_transaction']
     return validate_transaction(signed_transaction, propagate=True)


### PR DESCRIPTION
Nodes are currently accepting txns already in the state and broadcasting. These transactions are skipped at the time of block creation but still causing network traffic. 