### PR TITLE
Fix single node fork post consensus

### DIFF
--- a/app/config/constants.py
+++ b/app/config/constants.py
@@ -4,7 +4,7 @@ import os
 from app.config.ntypes import NEWRL_TOKEN_CODE, NUSD_TOKEN_CODE
 
 
-SOFTWARE_VERSION = "1.7.5"
+SOFTWARE_VERSION = "1.7.6"
 
 
 NEWRL_ENV = os.environ.get('NEWRL_ENV')

--- a/app/core/blockchain/blockchain.py
+++ b/app/core/blockchain/blockchain.py
@@ -209,7 +209,7 @@ def add_block(cur, block, hash=None, is_state_reconstruction=False):
     if not is_state_reconstruction:
         last_block = get_last_block(cur)
         if last_block is not None and last_block['hash'] != block['previous_hash']:
-            print('Previous block hash does not match current block data')
+            logger.warn('Previous block hash does not match current block data')
             return False
     # Needed for backward compatibility of blocks
     block_index = block['block_index'] if 'block_index' in block else block['index']

--- a/app/core/consensus/consensus.py
+++ b/app/core/consensus/consensus.py
@@ -50,6 +50,7 @@ def add_my_receipt_to_block(block, vote=BLOCK_VOTE_VALID):
     for receipt in block['receipts']:
         if receipt['public_key'] == my_receipt['public_key']:
             my_receipt_already_added = True
+            break
     if not my_receipt_already_added:
         block['receipts'].append(my_receipt)
         return my_receipt

--- a/app/core/fs/temp_manager.py
+++ b/app/core/fs/temp_manager.py
@@ -71,7 +71,7 @@ def store_receipt_to_temp(receipt, folder=TMP_PATH):
     return new_file_name
 
 
-def append_receipt_to_block(block, new_receipt):
+def append_receipt_to_block(block, new_receipt) -> dict or None:
     receipt_already_exists = False
     for receipt in block['receipts']:
         if receipt['public_key'] == new_receipt['public_key']:
@@ -80,9 +80,9 @@ def append_receipt_to_block(block, new_receipt):
     
     if not receipt_already_exists:
         block['receipts'].append(new_receipt)
-        return True
+        return block
     
-    return False
+    return None
 
 
 def append_receipt_to_block_in_storage(receipt):


### PR DESCRIPTION
When a newly minted block is being consensus checked by a node after adding it's receipt, it propagates it to the network if consensus valid. But a bug causing the node's receipt to be missing from the block being propagated. This PR attempts to fix this.