### PR TITLE
avoid minority fork creation in committee

### DIFF
--- a/app/config/constants.py
+++ b/app/config/constants.py
@@ -4,7 +4,7 @@ import os
 from app.config.ntypes import NEWRL_TOKEN_CODE, NUSD_TOKEN_CODE
 
 
-SOFTWARE_VERSION = "1.7.6"
+SOFTWARE_VERSION = "1.7.7"
 
 
 NEWRL_ENV = os.environ.get('NEWRL_ENV')

--- a/app/core/p2p/sync_chain.py
+++ b/app/core/p2p/sync_chain.py
@@ -141,14 +141,16 @@ def receive_block(block):
         store_block_to_temp(block)
         if am_i_in_current_committee():
             if validate_block(block):
-                my_receipt = add_my_receipt_to_block(block, vote=BLOCK_VOTE_VALID)
+                # Block might be mutated post validate_block call/accept_block call. Hence using original_block
+                my_receipt = add_my_receipt_to_block(original_block, vote=BLOCK_VOTE_VALID)
                 if my_receipt:
-                    consensus_adding_my_receipt = get_committee_consensus(block)
+                    consensus_adding_my_receipt = get_committee_consensus(original_block)
                     if consensus_adding_my_receipt == BLOCK_CONSENSUS_VALID:
-                        logger.info('Block satisfies valid consensus after adding my receipt. Accepting and broadcasting.')
-                        consensus_achieved_block = append_receipt_to_block(original_block, my_receipt)
-                        if accept_block(consensus_achieved_block, block['hash']):
-                            broadcast_block(consensus_achieved_block)
+                        logger.info('Block satisfies valid consensus after adding my receipt. Broadcasting to network.')
+                        # if accept_block(consensus_achieved_block, block['hash']):
+                        # get_committee_consensus will add the current node's receipt to the block
+                        # Broadcasting consensus achieved block
+                        broadcast_block(original_block)
                     elif consensus_adding_my_receipt == BLOCK_CONSENSUS_NA:
                         committee = get_committee_for_current_block()
                         broadcast_receipt(my_receipt, nodes=committee)


### PR DESCRIPTION
A minority fork is being created when the committee themselves accept the block and fail to propagate it to the reset of the network in a specific instance where the receipts adequate for consensus is not included in the broadcasted block. This PR aims to fix it. 