### PR TITLE
Remove tx propagation timeout, fix snapshot cp

### DIFF
--- a/app/config/constants.py
+++ b/app/config/constants.py
@@ -4,7 +4,7 @@ import os
 from app.config.ntypes import NEWRL_TOKEN_CODE, NUSD_TOKEN_CODE
 
 
-SOFTWARE_VERSION = "1.7.7"
+SOFTWARE_VERSION = "1.7.8"
 
 
 NEWRL_ENV = os.environ.get('NEWRL_ENV')

--- a/app/core/blockchain/validator.py
+++ b/app/core/blockchain/validator.py
@@ -85,7 +85,7 @@ def validate(transaction, propagate=False, validate_economics=True):
 
         if propagate and not IS_TEST:
             # Broadcast transaction to peers via HTTP
-            if transaction['transaction']['timestamp'] > get_corrected_time_ms() - MEMPOOL_TRANSACTION_LIFETIME_SECONDS * 1000:
+            # if transaction['transaction']['timestamp'] > get_corrected_time_ms() - MEMPOOL_TRANSACTION_LIFETIME_SECONDS * 1000:
                 exclude_nodes = transaction['peers_already_broadcasted'] if 'peers_already_broadcasted' in transaction else None
                 propogate_transaction_to_peers(
                     transaction_manager.get_transaction_complete(),

--- a/app/core/p2p/sync_chain.py
+++ b/app/core/p2p/sync_chain.py
@@ -600,7 +600,9 @@ def quick_sync(db_url):
 
         # Only copy if the downloaded db has more blocks than local
         if blocks[0] > existing_block[0]:
-            subprocess.call(["mv", downloaded_db_path, NEWRL_DB])
+            snapshot_file = NEWRL_DB + '.snapshot'
+            subprocess.call(["mv", downloaded_db_path, snapshot_file])
+            subprocess.call(["cp", snapshot_file, NEWRL_DB])
     except Exception as e:
         logger.info('Removing local db and using downloaded db')
         subprocess.call(["mv", downloaded_db_path, NEWRL_DB])


### PR DESCRIPTION
- Transactions older than `MEMPOOL_TRANSACTION_LIFETIME_SECONDS` are not propagated through the nodes. This change removes that timeout.
- Downloaded snapshots are not copied to current node's snapshot file but instead only replaced to newrl.db. This causes snapshot to be downloaded again if needed by the node. This is fixed here.