### PR TITLE
added fee validation fix

### DIFF
--- a/app/core/blockchain/transactionmanager.py
+++ b/app/core/blockchain/transactionmanager.py
@@ -230,7 +230,7 @@ class Transactionmanager:
         # from mempool only include transactions that reduce balance and not those that increase
         # check if the sender has enough balance to spend
         self.validity = 0
-
+        
         if not validate_transaction_fee(self.transaction, self.signatures, cur=cur):
             logger.error("Fee validation failed")
             self.errors.append("Fee validation failed")

--- a/app/core/blockchain/updater.py
+++ b/app/core/blockchain/updater.py
@@ -27,8 +27,8 @@ from ..p2p.peers import get_peers, init_bootstrap_nodes, remove_dead_peers
 from ..p2p.utils import is_my_address
 from ..helpers.utils import BufferedLog, get_time_ms
 from .blockchain import Blockchain, get_last_block, get_last_block_index
-from app.core.blockchain.transactionmanager import Transactionmanager, get_valid_addresses
-from app.core.blockchain.state_updater import pay_fee_for_transaction, update_db_states
+from app.core.blockchain.transactionmanager import Transactionmanager, get_valid_addresses, validate_transaction_fee
+from app.core.blockchain.state_updater import pay_fee_for_transaction, update_db_states, validate_pay_fee_for_transaction
 from ..crypto.crypto import calculate_hash, sign_object, _private, _public
 from ..consensus.consensus import generate_block_receipt
 from ..db.db_updater import transfer_tokens_and_update_balances, get_wallet_token_balance
@@ -98,7 +98,8 @@ def run_updater(add_to_chain=False):
         #     os.remove(file)
         #     continue
         # Pay fee for transaction. If payee doesn't have enough funds, remove transaction
-        if transaction['type'] != TRANSACTION_MINER_ADDITION and not pay_fee_for_transaction(cur, transaction, get_wallet()['address']):
+        if transaction['type'] != TRANSACTION_MINER_ADDITION and not validate_pay_fee_for_transaction(cur, transaction, get_wallet()['address']):
+            logger.info("Removing txn as fee validation failed")
             os.remove(file)
             continue
         econ_result = tmtemp.econvalidator(cur)

--- a/app/core/db/db_updater.py
+++ b/app/core/db/db_updater.py
@@ -215,13 +215,36 @@ def get_kyc_doc_hash_json(kyc_docs, kyc_doc_hashes):
     return json.dumps(doc_list)
 
 
-def get_wallet_token_balance(cur, wallet_address, token_code):
-    balance_cursor = cur.execute('SELECT balance FROM balances WHERE wallet_address = :address AND tokencode = :tokencode', {
-        'address': wallet_address, 'tokencode': token_code})
-    balance_row = balance_cursor.fetchone()
-    balance = balance_row[0] if balance_row is not None else 0
-    return balance
+# def get_wallet_token_balance(cur, wallet_address, token_code):
 
+#     balance_cursor = cur.execute('SELECT balance FROM balances WHERE wallet_address = :address AND tokencode = :tokencode', {
+#         'address': wallet_address, 'tokencode': token_code})
+#     balance_row = balance_cursor.fetchone()
+#     #    balance = balance_row[0] if balance_row is not None else 0
+#     logger.info(f"{balance_row} for {wallet_address} {token_code}" )
+#     if balance_row is not None:
+#         balance = balance_row[0] 
+#     else:
+#         logger.error("None 0")
+#         balance = 0
+
+#     return balance
+
+def get_wallet_token_balance(cur, wallet_address, token_code):
+    try:
+        balance_cursor = cur.execute('SELECT balance FROM balances WHERE wallet_address = :address AND tokencode = :tokencode', {
+            'address': wallet_address, 'tokencode': token_code})
+        balance_row = balance_cursor.fetchone()
+        if balance_row:
+            balance = balance_row[0]
+            logging.info(f"Retrieved balance: {balance} for wallet: {wallet_address} token: {token_code}")
+        else:
+            balance = 0
+            logging.warning(f"No balance record found for wallet: {wallet_address}, token: {token_code}. Defaulting to 0.")
+    except Exception as e:
+        logging.error(f"Error retrieving balance for wallet: {wallet_address}, token: {token_code}. Error: {e}")
+        balance = 0
+    return balance
 
 def add_tx_to_block(cur, block_index, transactions):
     for transaction_signature in transactions:


### PR DESCRIPTION
For fee validation, fee payment method is used. Added new method and used it.  Replaced it along with some logs
`        if transaction['type'] != TRANSACTION_MINER_ADDITION and not pay_fee_for_transaction(cur, transaction, get_wallet()['address']):`
is replaced with
`        if transaction['type'] != TRANSACTION_MINER_ADDITION and not validate_pay_fee_for_transaction(cur, transaction, get_wallet()['address']):`