### PR TITLE
revert last empty block on fork due to sentinel

### DIFF
--- a/app/core/blockchain/blockchain.py
+++ b/app/core/blockchain/blockchain.py
@@ -18,7 +18,7 @@ from ..fs.temp_manager import remove_block_from_temp
 from ...config.constants import BLOCK_TIME_INTERVAL_SECONDS, NEWRL_DB, NO_BLOCK_TIMEOUT
 from ..helpers.utils import get_time_ms
 from ..crypto.crypto import calculate_hash
-from .state_updater import state_cleanup, update_db_states, update_miners, update_trust_scores
+from .state_updater import revert_last_empty_block, state_cleanup, update_db_states, update_miners, update_trust_scores
 from ..helpers.utils import get_time_ms
 from ..auth.auth import get_node_wallet_address
 from ..fs.mempool_manager import remove_transaction_from_mempool
@@ -210,6 +210,11 @@ def add_block(cur, block, hash=None, is_state_reconstruction=False):
         last_block = get_last_block(cur)
         if last_block is not None and last_block['hash'] != block['previous_hash']:
             logger.warn('Previous block hash does not match current block data')
+            
+            # If the previous block is for mininig timeout, revert it
+            if last_block['status'] == BLOCK_STATUS_MINING_TIMEOUT:
+                logger.warn('Reverting last block as it is empty')
+                revert_last_empty_block(cur, last_block)
             return False
     # Needed for backward compatibility of blocks
     block_index = block['block_index'] if 'block_index' in block else block['index']
@@ -279,7 +284,7 @@ def get_last_block(cur=None):
             cur = con.cursor()
             cursor_opened_inside = True
         last_block_cursor = cur.execute(
-            'SELECT block_index, hash, timestamp FROM blocks ORDER BY block_index DESC LIMIT 1'
+            'SELECT block_index, hash, timestamp, status, expected_miner FROM blocks ORDER BY block_index DESC LIMIT 1'
         )
         last_block = last_block_cursor.fetchone()
 
@@ -293,7 +298,9 @@ def get_last_block(cur=None):
         return {
             'index': last_block[0],
             'hash': last_block[1],
-            'timestamp': last_block[2]
+            'timestamp': last_block[2],
+            'status': last_block[3],
+            'expected_miner': last_block[4]
         }
     else:
         return None

--- a/app/core/blockchain/state_updater.py
+++ b/app/core/blockchain/state_updater.py
@@ -503,6 +503,15 @@ def handle_sc_transaction(cur, transaction, creator_wallet, newblockindex):
             process_txn(cur,transaction_all,newblockindex)   
  
 
+def revert_last_empty_block(cur, last_block):
+    add_miner(
+        cur,
+        last_block['expected_miner'],
+        '1.1.1.1',
+        get_corrected_time_ms(),
+        last_block['index']  # TODO - This is a hack. Need to fix this.
+    )
+    cur.execute('DELETE FROM blocks where block_index = ?', (last_block['index'],))
  
     
 def state_cleanup(cur, block):


### PR DESCRIPTION
This PR aims to solve forks created due to empty blocks from sentinel being received by some nodes while the majority accepts a valid block created by the miner. The fix here is to delete the empty block created by sentinel on the forking node and it's change in the miners table.

An issue with this PR is the last block and the timestamp for the `expected_miner` is unknown as it's removed from the miners table when the empty block is added. The current block and timestamp is added instead of the real block index. This cause an inconsistency in the miners table till the `expected_miner`'s next broadcast is included in the chain or worse till the chain moves ahead by 1000 blocks.